### PR TITLE
Make `TimeoutError` have a proper "message" in the stack trace

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -1,8 +1,8 @@
 // Copyright (c) 2015 David M. Lee, II
 'use strict';
 
-var pt = require('../index.js');
-var assert = require('assert');
+const pt = require('../index.js');
+const assert = require('assert');
 
 function later(when) {
   return new Promise(function(resolve, reject) {
@@ -27,6 +27,8 @@ describe('promise-timeout', function() {
           assert.fail('should not have resolved');
         }, function(err) {
           assert(err.stack.includes('test.js'));
+          assert(err.stack.startsWith('TimeoutError: Promise did not'));
+          assert.equal(err.name, 'TimeoutError');
         });
     });
 });


### PR DESCRIPTION
Before:

```
> console.log(err.stack)
Error
    at new module.exports.TimeoutError (/Code/promise-timeout/index.js:44:16)
    at repl:1:13
    at Script.runInThisContext (vm.js:91:20)
    …
```

Now:

```
> console.log(err.stack)
TimeoutError: Promise did not resolve within 2000ms
    at repl:1:13
    at Script.runInThisContext (vm.js:91:20)
    …
```